### PR TITLE
Allow choice for ambiguous forms + support for other POS + bug fixes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 2018-2019, Avyay Varadarajan (@avyayv)
 2018-2019, Jonathan Washington (@jonorthwash)
 2019, Alberto Navalon Lillo <albertonl.dev@gmail.com>
+2020, Diogo S.C. Fernandes (@diogoscf)

--- a/kaz.html
+++ b/kaz.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" type="text/javascript"></script>
 <script src="paradigmbrowser.js" type="text/javascript"></script>
+<link rel="stylesheet" type="text/css" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css">
 
 <html>
 <style>
@@ -22,7 +24,12 @@
 <input id='ParadigmText' placeholder="Text to see Paradigms"></input>
 <button type="button" onclick="paradigm()">See Paradigms</button><br />
 
-<input type="hidden" data-remove-tags="ger.nom"></input>
+<input type="hidden" id="noremove" data-no-remove-tags="tv.iv" />
+<input type="hidden" id="alertmsg" data-msg="The text introduced is not a valid verb. Please, try another token." />
+<div id="selection">
+  <p>The text introduced is ambiguous. Please select the verb you wanted to enter:</p>
+</div>
+<input type="hidden" id="pickmsg" data-msg="The text introduced is ambiguous. Please select the verb you wanted to enter:" />
 
 Infinitives:
 <ul>

--- a/kaz.html
+++ b/kaz.html
@@ -24,7 +24,8 @@
 <input id='ParadigmText' placeholder="Text to see Paradigms"></input>
 <button type="button" onclick="paradigm()">See Paradigms</button><br />
 
-<input type="hidden" id="noremove" data-no-remove-tags="tv.iv" />
+<input type="hidden" id="noremove" data-no-remove-tags="tv,iv" />
+<input type="hidden" id="poscat" data-pos-category="verb" />
 <input type="hidden" id="alertmsg" data-msg="The text introduced is not a valid verb. Please, try another token." />
 <div id="selection">
   <p>The text introduced is ambiguous. Please select the verb you wanted to enter:</p>

--- a/paradigmbrowser.html
+++ b/paradigmbrowser.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" type="text/javascript"></script>
 <script src="paradigmbrowser.js" type="text/javascript"></script>
+<link rel="stylesheet" type="text/css" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css">
 
 <html>
 <body id='body'>
@@ -10,7 +12,12 @@
 <input id='ParadigmText' placeholder="Text to see Paradigms"></input>
 <button type="button" onclick="paradigm()">See Paradigms</button>
 
-<input type="hidden" data-remove-tags="inf"></input>
+<input type="hidden" id="noremove" data-no-remove-tags="tv.iv.sep.fs.fm" />
+<input type="hidden" id="alertmsg" data-msg="The text introduced is not a valid verb. Please, try another token." />
+<div id="selection">
+  <p>The text introduced is ambiguous. Please select the verb you wanted to enter:</p>
+</div>
+
 
 <table id="table">
   <tr>

--- a/paradigmbrowser.html
+++ b/paradigmbrowser.html
@@ -12,7 +12,8 @@
 <input id='ParadigmText' placeholder="Text to see Paradigms"></input>
 <button type="button" onclick="paradigm()">See Paradigms</button>
 
-<input type="hidden" id="noremove" data-no-remove-tags="tv.iv.sep.fs.fm" />
+<input type="hidden" id="noremove" data-no-remove-tags="tv,iv,sep,fs,fm" />
+<input type="hidden" id="poscat" data-pos-category="verb" />
 <input type="hidden" id="alertmsg" data-msg="The text introduced is not a valid verb. Please, try another token." />
 <div id="selection">
   <p>The text introduced is ambiguous. Please select the verb you wanted to enter:</p>

--- a/paradigmbrowser.js
+++ b/paradigmbrowser.js
@@ -1,169 +1,161 @@
-
-var hiddenTags = []
-var tagsNotToAdd = []
+var hiddenTags = [];
 
 //Specify APY URL
-var APY_URL = 'https://beta.apertium.org/apy/'
+const APY_URL = "https://beta.apertium.org/apy/";
 
+var selectionPrompt;
 //Allows for Paradigm after you have typed the space bar
 $(document).ready(function () {
   $(window).keypress(function (e) {
-    if (e.key === ' ' || e.key === 'Spacebar') {
-      e.preventDefault()
-      paradigm()
+    if (e.key === " " || e.key === "Spacebar") {
+      e.preventDefault();
+      paradigm();
     }
-  })
-})
+  });
+  selectionPrompt = $("#selection");
+  selectionPrompt.dialog({
+    autoOpen: false,
+    closeOnEscape: false
+  });
+});
 
 //Function to get the tags given a jquery object
 function getTags(obj) {
-
-  if($(obj).data('tags') != undefined) {
-
+  if ($(obj).data("tags") !== undefined) {
     var completedString = "";
-    $(obj).text("")
-    $.each($(obj).data('tags').split('.'), function(index, value) {
+    $(obj).text("");
+    $.each($(obj).data("tags").split("."), function (index, value) {
       completedString += "<" + value + ">";
     });
 
-    if(hiddenTags.indexOf(completedString) > -1 == false){
+    if (!hiddenTags.includes(completedString)) {
       hiddenTags.push(completedString);
     }
-
   }
 }
 
 //Function to edit the values of the tags
 function editTags(obj, find, change) {
-
   //see if tags exist
-  if($(obj).data('tags') != undefined) {
-    var tags = $(obj).data('tags').split('.');
-
-    str = "<"
-
-    $.each($(tags), function(index, value) {
-      if(index < tags.length - 1) {
-        str += value + "><"
-      }else{
-        str += value + ">"
+  if ($(obj).data("tags") !== undefined) {
+    var tags = $(obj).data("tags").split(".");
+    var str = "<";
+    $.each($(tags), function (index, value) {
+      if (index < tags.length - 1) {
+        str += value + "><";
+      } else {
+        str += value + ">";
       }
     });
-
     //See if tags matches the tag in the html
-    if(str == find){
-
+    if (str === find) {
       //Find if the value should be added or not
-      if ((change.indexOf('#') > -1) == false && ($(obj).text().indexOf(change) > -1 == false)) {
+      if (!change.includes("#") && !$(obj).text().includes(change)) {
         $(obj).text($(obj).text() + change + " ");
       }
     }
   }
 }
 
-//Function to determine the tags to remove
-function removeTheseTags(obj) {
-  if($(obj).data('remove-tags') != undefined) {
-    var tags = $(obj).data('remove-tags').split('.');
-    var completedString = "";
-    $.each($(tags), function(index, value) {
-      tagsNotToAdd.push(value);
-    });
-  }
-}
-
 // Function to go through all tags and use the getTags function
 function runThruGettingTags() {
-  $("*").each(function(){
-    getTags(this);
+  $("*").each(function (key, obj) {
+    getTags(obj);
   });
 }
 
 // Function to see all tags and edit
 function runThruEditingNames(hiddenTagsValue, updatedValue) {
-  $("*").each(function(){
-    editTags(this, hiddenTagsValue, updatedValue)
+  $("*").each(function (key, el) {
+    editTags(el, hiddenTagsValue, updatedValue);
+  });
+}
+
+function generateParadigms(correctForm, lang) {
+  var firstTag = correctForm[0] + "<" + correctForm.slice(1).join("><") + ">";
+  //make sure that the hiddenTags variable does not add elements twice; clear the array
+  hiddenTags = [];
+  //get all tags and store in hiddenTags Variable
+  runThruGettingTags();
+  //iterate through words with base tags and add the hidden tags on the html onto this
+  $.each($(hiddenTags), function (hiddenTagIndex, hiddenTag) {
+    //query generate endpoint so we can see the end values
+    $.getJSON(APY_URL + "generate?lang=" + encodeURIComponent(lang) + "&q=" + encodeURIComponent(firstTag + hiddenTag), function (data) {
+      //edit html values from the output of the APY
+      runThruEditingNames(hiddenTag, data[0][0]);
+    }, "html");
   });
 }
 
 //Function is called when button is pressed or when spacebar is pressed
 function paradigm() {
-
   $(document).ready(function () {
-
     //get values of the language and text to be paradigmed
-    var language = $('#Language').val();
-    var paradigmText = $('#ParadigmText').val();
-    var languagesWithFirstTag = ""
-
-    //go through all elements and see to remove all not
-    $('*').each(function(){
-      removeTheseTags(this);
-    })
+    var language = $("#Language").val();
+    var paradigmText = $("#ParadigmText").val();
+    var alertMessage = $("#alertmsg").data("msg");
+    var keepTags = [];
+    if ($("#noremove").length) {
+      keepTags = $("#noremove").data("no-remove-tags").split(".");
+    }
 
     //get JSON from the analyze endpoint to see the different forms of the word
-    $.getJSON(APY_URL + 'analyze?lang='+encodeURIComponent(language)+'&q='+encodeURIComponent(paradigmText), function(data,status) {
-      var arrOfWordsWithFirstTag = []
-      languagesWithFirstTag = data[0][0];
-      forms = languagesWithFirstTag.split('/');
+    $.getJSON(APY_URL + "analyze?lang=" + encodeURIComponent(language) + "&q=" + encodeURIComponent(paradigmText), function (data) {
+      var forms = data[0][0].split("/");
+      var isDataVerb = false;
+      var validForms = [];
       //iterate through all the forms of the word
-      $.each($(forms), function(index, value) {
-        //this is a temporary fix which should be changed when fixing #2
-        if(index == 1) {
-          //get the forms in array form
-          text = value.replace(new RegExp('><', 'g'), ".");
-          text = text.replace(new RegExp('<', 'g'), ".");
-          text = text.replace(new RegExp('>', 'g'), ".");
-          text = text.split(/[\s.]+/)
+      $.each($(forms), function (index, value) {
+        //get the forms in array form
+        var text = value.replace(new RegExp("><", "g"), ".");
+        text = text.replace(new RegExp("<", "g"), ".");
+        text = text.replace(new RegExp(">", "g"), ".");
+        text = text.split(/[\s.]+/);
 
-          string = ""
-
-          //get all the tags now with the tags we wanted removed, removed
-          $.each($(text), function(insideIndex, indString) {
-            if(insideIndex > 0 && indString != "" && tagsNotToAdd.indexOf(indString.trim()) > -1 == false && string.includes("<" + indString + ">") == false){
-              string += "<" + indString + ">";
-            }
-          });
-          //get the form of the word so it is ready to be queryed to generate endpoint
-          arrOfWordsWithFirstTag.push(value.split('<')[0]+string);
-          languagesWithFirstTag = arrOfWordsWithFirstTag;
-          //make sure that the hiddenTags variable does not add elements twice; clear the array
-          hiddenTags = []
-          //get all tags and store in hiddenTags Variable
-          runThruGettingTags()
-          //iterate through words with base tags and add the hidden tags on the html onto this
-          $.each($(languagesWithFirstTag), function(firstTagIndex, firstTag) {
-            if(isVerb(firstTag, paradigmText)) {
-              $.each($(hiddenTags), function(hiddenTagIndex, hiddenTag) {
-                //query generate endpoint so we can see the end values
-                $.getJSON(APY_URL + 'generate?lang='+encodeURIComponent(language)+'&q='+encodeURIComponent(firstTag+hiddenTag),function(data,status) {
-                  //edit html values from the output of the APY
-                  console.log(APY_URL + 'generate?lang='+encodeURIComponent(language)+'&q='+encodeURIComponent(firstTag+hiddenTag))
-                  runThruEditingNames(hiddenTag, data[0][0])
-                },'html');
-              });
-            } else {
-              alert("The text introduced is not a valid verb. Please, try another token.");
-              return 0;
-            }
-          });
+        text.forEach(function (el, idx) {
+          if (!keepTags.includes(el) && idx > 1) {
+            text.splice(idx);
+          }
+        });
+        //Check whether each form is a verb and whether it's already in validForms arr
+        var inArr = validForms.some((f) => text.every((t, i) => (t) === f[i]));
+        if (isVerb(text[0] + "<" + text[1] + ">", text[0]) && !inArr) {
+          isDataVerb = true;
+          validForms.push(text); //already split for convenience
         }
       });
-    },'html');
+      if (!isDataVerb) {
+        alert(alertMessage);
+        return false; //Stop running
+      }
+      if (validForms.length > 1) {
+        var buttons = [];
+        validForms.forEach(function (form) {
+          buttons.push({
+            text: form[0] + "<" + form.slice(1).join("><") + ">",
+            click: function () {
+              $(this).dialog("close");
+              generateParadigms(form, language);
+            }
+          });
+        });
+        selectionPrompt.dialog("option", "buttons", buttons);
+        selectionPrompt.dialog("open");
+      } else {
+        generateParadigms(validForms[0], language);
+      }
+    }, "html");
   });
-
 }
 
 function isVerb(firstTag, paradigmText) {
-  let dataIsVerb = false;
-
-  // symbols corresponding to verbs (http:/http://wiki.apertium.org/wiki/List_of_symbols#Part-of-speech_Categories)
+  var dataIsVerb = false;
+  // symbols corresponding to verbs (http://wiki.apertium.org/wiki/List_of_symbols#Part-of-speech_Categories)
   // in case any verb symbol is missing, you can simply add it to the back of the array
-  let verbSymbols = ['vblex', 'v', 'vbmod', 'vbser', 'vbhaver', 'vbdo'];
-
+  var verbSymbols = ["vblex", "v", "vbmod", "vbser", "vbhaver", "vbdo", "vaux"];
   // try the different symbols until we find the actual one, unless it's not a verb
-  $.each(verbSymbols, function(index, value) {
-    if(firstTag===paradigmText+"<"+value+">") {
+  $.each(verbSymbols, function (index, value) {
+    if (firstTag === paradigmText + "<" + value + ">") {
       dataIsVerb = true;
       return false;
     }

--- a/spa.html
+++ b/spa.html
@@ -120,6 +120,7 @@
 		</div>
 
 		<input type="hidden" id="alertmsg" data-msg="The text introduced is not a valid verb. Please, try another token." />
+		<input type="hidden" id="poscat" data-pos-category="verb" />
 		<div id="selection">
 		  <p>The text introduced is ambiguous. Please select the verb you wanted to enter:</p>
 		</div>

--- a/spa.html
+++ b/spa.html
@@ -5,12 +5,14 @@
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta http-equiv="X-UA-Compatible" content="ie=edge">
-		
-		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
-		<script src="paradigmbrowser.js" type="text/javascript"></script>
 
-		<link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-		<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+		<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" type="text/javascript"></script>
+		<script src="paradigmbrowser.js" type="text/javascript"></script>
+		<link rel="stylesheet" type="text/css" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css">
+
+		<link rel="stylesheet" type="text/css" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+		<link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 		<style type="text/css">
 			#personal, #non-personal {
 				text-align: center;
@@ -117,7 +119,10 @@
 			</div>
 		</div>
 
-		<input type="hidden" data-remove-tags="inf"/>
+		<input type="hidden" id="alertmsg" data-msg="The text introduced is not a valid verb. Please, try another token." />
+		<div id="selection">
+		  <p>The text introduced is ambiguous. Please select the verb you wanted to enter:</p>
+		</div>
 
 		<div id="non-personal"><!-- non-personal forms / formas no personales -->
 			<h2>Non-personal forms</h2>
@@ -472,7 +477,7 @@
 					<h4>Past imperfect</h4>
 					<div align="center" class="alert alert-info" role="alert" style="width: 100%;">
 						<i class="fa fa-search"></i>&nbsp;
-						This tense has two possible structures. Only one of them is being displayed, as given by <a class="alert-link" href="https://github.com/apertium/apertium-apy">Apertium APY</a> (more information about this and other tenses: <a class="alert-link" href="https://www.rae.es/diccionario-panhispanico-de-dudas/apendices/modelos-de-conjugacion-verbal">rae.es</a>).
+						This tense has two possible structures. Only one of them is being displayed, as given by <a class="alert-link" href="//github.com/apertium/apertium-apy">Apertium APY</a> (more information about this and other tenses: <a class="alert-link" href="//www.rae.es/diccionario-panhispanico-de-dudas/apendices/modelos-de-conjugacion-verbal">rae.es</a>).
 					</div>
 					<table>
 						<tr>
@@ -526,8 +531,8 @@
 					-->
 					<div align="center" class="alert alert-warning" role="alert" style="width: 100%;">
 						<i class="fa fa-exclamation-triangle"></i>&nbsp;<b>Warning!</b><br>
-						<a class="alert-link" href="https://github.com/apertium/apertium-apy">Apertium APY</a> does not currently support the generation of future subjunctive forms.<br>
-						You can also manually generate them with the information given in the <a class="alert-link" href="https://www.rae.es/diccionario-panhispanico-de-dudas/apendices/modelos-de-conjugacion-verbal">rae.es page listed above</a> (Spanish) or in <a class="alert-link" href="https://www.spanishdict.com/guide/spanish-future-subjunctive">spanishdict.com</a> (English).<br>
+						<a class="alert-link" href="//github.com/apertium/apertium-apy">Apertium APY</a> does not currently support the generation of future subjunctive forms.<br>
+						You can also manually generate them with the information given in the <a class="alert-link" href="//www.rae.es/diccionario-panhispanico-de-dudas/apendices/modelos-de-conjugacion-verbal">rae.es page listed above</a> (Spanish) or in <a class="alert-link" href="//www.spanishdict.com/guide/spanish-future-subjunctive">spanishdict.com</a> (English).<br>
 						We apologize for this inconvenience.
 					</div>
 				</div>
@@ -659,11 +664,11 @@
 		<hr>
 
 		<footer>
-			<a href="https://github.com/apertium/apertium-paradigm-generator">Apertium Paradigm Generator</a><br>
+			<a href="//github.com/apertium/apertium-paradigm-generator">Apertium Paradigm Generator</a><br>
 			Alberto Navalón Lillo, 2019<br>
-			<a href="https://github.com/albertonl">GitHub</a>,&nbsp;<a href="mailto:albertonl.dev@gmail.com">albertonl.dev@gmail.com</a><br><br>
+			<a href="//github.com/albertonl">GitHub</a>,&nbsp;<a href="mailto:albertonl.dev@gmail.com">albertonl.dev@gmail.com</a><br><br>
 
-			&copy; <a href="https://apertium.org">Apertium</a>
+			&copy; <a href="//apertium.org">Apertium</a>
 		</footer>
 		<!-- trigger button click on enter -->
 		<script type="text/javascript">


### PR DESCRIPTION
This was originally intended to be a fix for the issues outlined in [this GCI task](https://codein.withgoogle.com/dashboard/task-instances/4793280907182080/), but I ended up also adding the possibility to input a verb in any form (and if it's ambiguous, the user selects the intended form, using a `jQuery UI` prompt) and now the `JS` is ready for paradigms for other POS categories.
For the fixes:
- The problem with `https` was that it was trying to get stuff with `http`, which is considered insecure and therefore blocked. This has been fixed by making it load with the files' transfer protocol
- The problem with returning a lot of "invalid verb forms" was due to a lack of consideration for tags that weren't removed (and it was, for example, checking if `<v><tv>` was a valid verb category)
- The alerts are customizable with an `html` tag: `<input type="hidden" id="alertmsg" data-msg="ALERT MSG HERE" />`

As for the selection prompt, it must be added with
```
<div id="selection">
    <p>SELECTION MSG HERE</p>
</div>
```
The JS code will format it properly

And instead of specifying tags to remove, you should now specify tags _not_ to remove, with `data-no-remove-tags` in an element with the `noremove` id